### PR TITLE
Windows regex fix

### DIFF
--- a/internal/services/godot/fetcher/fetcher_darwin.go
+++ b/internal/services/godot/fetcher/fetcher_darwin.go
@@ -27,7 +27,9 @@ func (f *Fetcher) LinkPath(semver semver.Semver) string {
 }
 
 func (f *Fetcher) locateExecutable(root string) (string, error) {
-	return utils.LocateExecutable(ExecutableRegex, root, true)
+	return utils.LocateExecutable(func(filename string) bool {
+		return ExecutableRegex.MatchString(filename)
+	}, root, true)
 }
 
 func New(config *config.Config) *Fetcher {

--- a/internal/services/godot/fetcher/fetcher_linux.go
+++ b/internal/services/godot/fetcher/fetcher_linux.go
@@ -27,7 +27,9 @@ func (f *Fetcher) LinkPath(semver semver.Semver) string {
 }
 
 func (f *Fetcher) locateExecutable(root string) (string, error) {
-	return utils.LocateExecutable(ExecutableRegex, root, false)
+	return utils.LocateExecutable(func(filename string) bool {
+		return ExecutableRegex.MatchString(filename)
+	}, root, false)
 }
 
 func New(config *config.Config) *Fetcher {

--- a/internal/services/godot/fetcher/fetcher_windows.go
+++ b/internal/services/godot/fetcher/fetcher_windows.go
@@ -9,10 +9,12 @@ import (
 	"github.com/bashidogames/gevm/semver"
 )
 
-const EXECUTABLE_REGEX_PATTERN = "Godot((?!console).)*?[.]exe"
-const LINK_FILENAME = "godot"
+const EXECUTABLE_REGEX_PATTERN = "Godot(.*?)[.]exe"
+const INVALID_REGEX_PATTERN = "(console)[.]exe"
+const LINK_FILENAME = "godot.exe"
 
 var ExecutableRegex = regexp.MustCompile(EXECUTABLE_REGEX_PATTERN)
+var InvalidRegex = regexp.MustCompile(INVALID_REGEX_PATTERN)
 
 type Fetcher struct {
 	Config *config.Config
@@ -27,7 +29,9 @@ func (f *Fetcher) LinkPath(semver semver.Semver) string {
 }
 
 func (f *Fetcher) locateExecutable(root string) (string, error) {
-	return utils.LocateExecutable(ExecutableRegex, root, true)
+	return utils.LocateExecutable(func(filename string) bool {
+		return ExecutableRegex.MatchString(filename) && !InvalidRegex.MatchString(filename)
+	}, root, false)
 }
 
 func New(config *config.Config) *Fetcher {

--- a/internal/services/shortcuts/fetcher/fetcher_darwin.go
+++ b/internal/services/shortcuts/fetcher/fetcher_darwin.go
@@ -41,7 +41,9 @@ func (f *Fetcher) shortcutFilename(semver semver.Semver) string {
 }
 
 func (f *Fetcher) locateExecutable(root string) (string, error) {
-	return utils.LocateExecutable(ExecutableRegex, root, true)
+	return utils.LocateExecutable(func(filename string) bool {
+		return ExecutableRegex.MatchString(filename)
+	}, root, true)
 }
 
 func New(config *config.Config) *Fetcher {

--- a/internal/services/shortcuts/fetcher/fetcher_linux.go
+++ b/internal/services/shortcuts/fetcher/fetcher_linux.go
@@ -41,7 +41,9 @@ func (f *Fetcher) shortcutFilename(semver semver.Semver) string {
 }
 
 func (f *Fetcher) locateExecutable(root string) (string, error) {
-	return utils.LocateExecutable(ExecutableRegex, root, false)
+	return utils.LocateExecutable(func(filename string) bool {
+		return ExecutableRegex.MatchString(filename)
+	}, root, false)
 }
 
 func New(config *config.Config) *Fetcher {

--- a/internal/services/shortcuts/fetcher/fetcher_windows.go
+++ b/internal/services/shortcuts/fetcher/fetcher_windows.go
@@ -10,11 +10,13 @@ import (
 	"github.com/bashidogames/gevm/semver"
 )
 
-const EXECUTABLE_REGEX_PATTERN = "Godot((?!console).)*?[.]exe"
+const EXECUTABLE_REGEX_PATTERN = "Godot(.*?)[.]exe"
+const INVALID_REGEX_PATTERN = "(console)[.]exe"
 const SHORTCUT_FILENAME = "Godot %s.lnk"
 const SHORTCUT_NAME = "Godot %s"
 
 var ExecutableRegex = regexp.MustCompile(EXECUTABLE_REGEX_PATTERN)
+var InvalidRegex = regexp.MustCompile(INVALID_REGEX_PATTERN)
 
 type Fetcher struct {
 	Config *config.Config
@@ -41,7 +43,9 @@ func (f *Fetcher) shortcutFilename(semver semver.Semver) string {
 }
 
 func (f *Fetcher) locateExecutable(root string) (string, error) {
-	return utils.LocateExecutable(ExecutableRegex, root, false)
+	return utils.LocateExecutable(func(filename string) bool {
+		return ExecutableRegex.MatchString(filename) && !InvalidRegex.MatchString(filename)
+	}, root, false)
 }
 
 func New(config *config.Config) *Fetcher {

--- a/internal/utils/os.go
+++ b/internal/utils/os.go
@@ -6,10 +6,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 )
 
-func LocateExecutable(regex *regexp.Regexp, root string, isDir bool) (string, error) {
+func LocateExecutable(callback func(string) bool, root string, isDir bool) (string, error) {
 	var result string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -20,7 +19,7 @@ func LocateExecutable(regex *regexp.Regexp, root string, isDir bool) (string, er
 			return nil
 		}
 
-		if !regex.MatchString(filepath.Base(path)) {
+		if !callback(filepath.Base(path)) {
 			return nil
 		}
 

--- a/semver/semver.go
+++ b/semver/semver.go
@@ -14,10 +14,10 @@ const RELEASE_REGEX_PATTERN = "((dev|alpha|beta|rc)([1-9][0-9]*|0)|stable)([-_.]
 const RELVER_REGEX_PATTERN = "(" + VERSION_REGEX_PATTERN + ")[-_.](" + RELEASE_REGEX_PATTERN + ")"
 const SEMVER_REGEX_PATTERN = RELVER_REGEX_PATTERN + "([-_.](mono))?"
 
-var VersionRegex = regexp.MustCompile("^" + VERSION_REGEX_PATTERN + "$")
-var ReleaseRegex = regexp.MustCompile("^" + RELEASE_REGEX_PATTERN + "$")
-var RelverRegex = regexp.MustCompile("^" + RELVER_REGEX_PATTERN + "$")
-var SemverRegex = regexp.MustCompile("^" + SEMVER_REGEX_PATTERN + "$")
+var VersionRegex = regexp.MustCompile(VERSION_REGEX_PATTERN)
+var ReleaseRegex = regexp.MustCompile(RELEASE_REGEX_PATTERN)
+var RelverRegex = regexp.MustCompile(RELVER_REGEX_PATTERN)
+var SemverRegex = regexp.MustCompile(SEMVER_REGEX_PATTERN)
 
 var ErrRegexFailed = errors.New("regex failed")
 


### PR DESCRIPTION
Fix the fetcher executable regex on windows failing. Golang doesn't support `?!` negative lookahead style regex so instead use 2 different patterns.