### PR TITLE
Quiet mode

### DIFF
--- a/cmd/gevm/main.go
+++ b/cmd/gevm/main.go
@@ -26,6 +26,7 @@ var CLI struct {
 
 	ConfigPath string `help:"Override which config path to use"`
 	Verbose    bool   `short:"v" help:"Use verbose debug logging"`
+	Quiet      bool   `short:"q" help:"Don't show progress"`
 }
 
 func main() {
@@ -34,6 +35,7 @@ func main() {
 	config, err := config.New(
 		config.OptionSetConfigPath(CLI.ConfigPath),
 		config.OptionSetVerbose(CLI.Verbose),
+		config.OptionSetQuiet(CLI.Quiet),
 	)
 	if err != nil {
 		log.Fatalf("failed to create config: %s", err)

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	ConfigPath string            `json:"-"`
 	Platform   platform.Platform `json:"-"`
 	Verbose    bool              `json:"-"`
+	Quiet      bool              `json:"-"`
 }
 
 func (c *Config) Reset() error {
@@ -198,5 +199,11 @@ func OptionSetConfigPath(configPath string) Option {
 func OptionSetVerbose(verbose bool) Option {
 	return func(config *Config) {
 		config.Verbose = verbose
+	}
+}
+
+func OptionSetQuiet(quiet bool) Option {
+	return func(config *Config) {
+		config.Quiet = quiet
 	}
 }

--- a/internal/downloading/downloading.go
+++ b/internal/downloading/downloading.go
@@ -15,7 +15,7 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
-func Download(url string, path string) error {
+func Download(url string, path string, quiet bool) error {
 	exists, err := utils.DoesExist(path)
 	if err != nil {
 		return fmt.Errorf("failed to check existence: %w", err)
@@ -37,6 +37,10 @@ func Download(url string, path string) error {
 		return fmt.Errorf("failed to parse header: %w", err)
 	}
 
+	if quiet {
+		utils.Printlnf("Downloading '%s'", filepath.Base(path))
+	}
+
 	progress := progressbar.NewOptions64(size,
 		progressbar.OptionSetDescription(fmt.Sprintf("Downloading '%s'", filepath.Base(path))),
 		progressbar.OptionSetWidth(20),
@@ -50,6 +54,7 @@ func Download(url string, path string) error {
 			BarStart:      "[",
 			BarEnd:        "]",
 		}),
+		progressbar.OptionSetVisibility(!quiet),
 	)
 
 	resp, err := http.Get(url)

--- a/internal/services/exporttemplates/exporttemplates.go
+++ b/internal/services/exporttemplates/exporttemplates.go
@@ -54,7 +54,9 @@ func (s *Service) Download(semver semver.Semver) error {
 		utils.Printlnf("Downloading to: %s", archivePath)
 	}
 
-	err = downloading.Download(asset.DownloadURL, archivePath)
+	quiet := s.Config.Quiet
+
+	err = downloading.Download(asset.DownloadURL, archivePath, quiet)
 	if errors.Is(err, downloading.ErrNotFound) {
 		utils.Printlnf("Export templates '%s' not found. Use 'gevm versions list' to see available versions.", semver.ExportTemplatesString())
 		return nil
@@ -149,7 +151,9 @@ func (s *Service) Install(semver semver.Semver) error {
 		utils.Printlnf("Downloading to: %s", archivePath)
 	}
 
-	err = downloading.Download(asset.DownloadURL, archivePath)
+	quiet := s.Config.Quiet
+
+	err = downloading.Download(asset.DownloadURL, archivePath, quiet)
 	if errors.Is(err, downloading.ErrNotFound) {
 		utils.Printlnf("Export templates '%s' not found. Use 'gevm versions list' to see available versions.", semver.ExportTemplatesString())
 		return nil

--- a/internal/services/godot/godot.go
+++ b/internal/services/godot/godot.go
@@ -55,7 +55,9 @@ func (s *Service) Download(semver semver.Semver) error {
 		utils.Printlnf("Downloading to: %s", archivePath)
 	}
 
-	err = downloading.Download(asset.DownloadURL, archivePath)
+	quiet := s.Config.Quiet
+
+	err = downloading.Download(asset.DownloadURL, archivePath, quiet)
 	if errors.Is(err, downloading.ErrNotFound) {
 		utils.Printlnf("Godot '%s' not found. Use 'gevm versions list' to see available versions.", semver.GodotString())
 		return nil
@@ -143,7 +145,9 @@ func (s *Service) Install(semver semver.Semver) error {
 		utils.Printlnf("Downloading to: %s", archivePath)
 	}
 
-	err = downloading.Download(asset.DownloadURL, archivePath)
+	quiet := s.Config.Quiet
+
+	err = downloading.Download(asset.DownloadURL, archivePath, quiet)
 	if errors.Is(err, downloading.ErrNotFound) {
 		utils.Printlnf("Godot '%s' not found. Use 'gevm versions list' to see available versions.", semver.GodotString())
 		return nil


### PR DESCRIPTION
Sometimes ci/cd logs can spam progress bar updates line by line which doesn't look great. So adding a quiet mode command line option which just prints the download url and doesn't display a progress bar.