### PR TITLE
Mapping warnings

### DIFF
--- a/cmd/gevm/main.go
+++ b/cmd/gevm/main.go
@@ -25,7 +25,7 @@ var CLI struct {
 	Cache           cache.Cache                     `cmd:"" help:"Run commands on the cache"`
 	Version         version.Version                 `cmd:"" help:"Print current version"`
 
-	LoggingLevel string `short:"l" enum:"nothing,error,warning,info,debug,trace" default:"debug" help:"Which log level to use"`
+	LoggingLevel string `short:"l" enum:"nothing,error,warning,info,debug,trace" default:"info" help:"Which log level to use"`
 	ConfigPath   string `help:"Override which config path to use"`
 	Silent       bool   `help:"Prevent progress bar log spam"`
 }

--- a/internal/archiving/archiving.go
+++ b/internal/archiving/archiving.go
@@ -18,7 +18,7 @@ func Unzip(logger logger.Logger, from string, to string) error {
 	}
 	defer reader.Close()
 
-	logger.Debug("Unzipping '%s'", filepath.Base(from))
+	logger.Info("Unzipping '%s'", filepath.Base(from))
 
 	err = unzip(reader, to)
 	if err != nil {

--- a/internal/downloading/downloading.go
+++ b/internal/downloading/downloading.go
@@ -23,7 +23,7 @@ func Download(logger logger.Logger, url string, path string, silent bool) error 
 	}
 
 	if exists {
-		logger.Debug("Cached '%s' found", filepath.Base(path))
+		logger.Info("Cached '%s' found", filepath.Base(path))
 		return nil
 	}
 
@@ -38,7 +38,7 @@ func Download(logger logger.Logger, url string, path string, silent bool) error 
 		return fmt.Errorf("failed to parse header: %w", err)
 	}
 
-	logger.Debug("Downloading '%s'", filepath.Base(path))
+	logger.Info("Downloading '%s'", filepath.Base(path))
 
 	progress := progressbar.NewOptions64(size,
 		progressbar.OptionSetDescription(fmt.Sprintf("'%s'", filepath.Base(path))),

--- a/internal/environment/github/github.go
+++ b/internal/environment/github/github.go
@@ -48,7 +48,7 @@ func (g *Github) FetchAsset(platform platform.Platform, semver semver.Semver) (*
 	url := fmt.Sprintf(ASSET_URL, semver.Relver.GodotString())
 	var data Data
 
-	g.Config.Logger.Trace("Fetching assets from url: %s", url)
+	g.Config.Logger.Trace("Fetching data from url: %s", url)
 
 	err := downloading.Fetch(url, func(header http.Header, bytes []byte) error {
 		err := json.Unmarshal(bytes, &data)

--- a/internal/environment/github/mappings/mappings.go
+++ b/internal/environment/github/mappings/mappings.go
@@ -49,3 +49,8 @@ var Mappings = map[platform.Platform]Mapping{
 		Arch:   []string{"32"},
 	},
 }
+
+var Overrides = map[platform.Platform][]string{
+	platform.DarwinAmd64: {"universal"},
+	platform.Darwin386:   {"universal"},
+}

--- a/internal/services/cache/cache.go
+++ b/internal/services/cache/cache.go
@@ -12,7 +12,7 @@ type Service struct {
 }
 
 func (s *Service) Clear() error {
-	s.Config.Logger.Trace("Attempting to clear cache directory: %s", s.Config.CacheDirectory)
+	s.Config.Logger.Debug("Attempting to clear cache directory: %s", s.Config.CacheDirectory)
 
 	err := os.RemoveAll(s.Config.CacheDirectory)
 	if err != nil {

--- a/internal/services/exporttemplates/exporttemplates.go
+++ b/internal/services/exporttemplates/exporttemplates.go
@@ -24,7 +24,7 @@ type Service struct {
 }
 
 func (s *Service) Download(semver semver.Semver) error {
-	s.Config.Logger.Trace("Attempting to download '%s' export templates...", semver.ExportTemplatesString())
+	s.Config.Logger.Debug("Attempting to download '%s' export templates...", semver.ExportTemplatesString())
 
 	asset, err := s.Environment.FetchExportTemplatesAsset(semver)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -47,8 +47,8 @@ func (s *Service) Download(semver semver.Semver) error {
 		return nil
 	}
 
-	s.Config.Logger.Trace("Downloading from: %s", asset.DownloadURL)
-	s.Config.Logger.Trace("Downloading to: %s", archivePath)
+	s.Config.Logger.Debug("Downloading from: %s", asset.DownloadURL)
+	s.Config.Logger.Debug("Downloading to: %s", archivePath)
 
 	err = downloading.Download(s.Config.Logger, asset.DownloadURL, archivePath, s.Config.Silent)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -64,7 +64,7 @@ func (s *Service) Download(semver semver.Semver) error {
 }
 
 func (s *Service) Uninstall(semver semver.Semver, logMissing bool) error {
-	s.Config.Logger.Trace("Attempting to uninstall '%s' export templates...", semver.ExportTemplatesString())
+	s.Config.Logger.Debug("Attempting to uninstall '%s' export templates...", semver.ExportTemplatesString())
 
 	targetDirectory := s.targetDirectory(semver)
 
@@ -81,7 +81,7 @@ func (s *Service) Uninstall(semver semver.Semver, logMissing bool) error {
 		return nil
 	}
 
-	s.Config.Logger.Trace("Removing directory: %s", targetDirectory)
+	s.Config.Logger.Debug("Removing directory: %s", targetDirectory)
 
 	err = os.RemoveAll(targetDirectory)
 	if err != nil {
@@ -93,7 +93,7 @@ func (s *Service) Uninstall(semver semver.Semver, logMissing bool) error {
 }
 
 func (s *Service) Install(semver semver.Semver) error {
-	s.Config.Logger.Trace("Attempting to install '%s' export templates...", semver.ExportTemplatesString())
+	s.Config.Logger.Debug("Attempting to install '%s' export templates...", semver.ExportTemplatesString())
 
 	asset, err := s.Environment.FetchExportTemplatesAsset(semver)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -134,8 +134,8 @@ func (s *Service) Install(semver semver.Semver) error {
 		return fmt.Errorf("cannot remove temp directory: %w", err)
 	}
 
-	s.Config.Logger.Trace("Downloading from: %s", asset.DownloadURL)
-	s.Config.Logger.Trace("Downloading to: %s", archivePath)
+	s.Config.Logger.Debug("Downloading from: %s", asset.DownloadURL)
+	s.Config.Logger.Debug("Downloading to: %s", archivePath)
 
 	err = downloading.Download(s.Config.Logger, asset.DownloadURL, archivePath, s.Config.Silent)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -146,16 +146,16 @@ func (s *Service) Install(semver semver.Semver) error {
 		return fmt.Errorf("download failed: %w", err)
 	}
 
-	s.Config.Logger.Trace("Unzipping from: %s", archivePath)
-	s.Config.Logger.Trace("Unzipping to: %s", rootDirectory)
+	s.Config.Logger.Debug("Unzipping from: %s", archivePath)
+	s.Config.Logger.Debug("Unzipping to: %s", rootDirectory)
 
 	err = archiving.Unzip(s.Config.Logger, archivePath, rootDirectory)
 	if err != nil {
 		return fmt.Errorf("unzip failed: %w", err)
 	}
 
-	s.Config.Logger.Trace("Moving from: %s", tempDirectory)
-	s.Config.Logger.Trace("Moving to: %s", targetDirectory)
+	s.Config.Logger.Debug("Moving from: %s", tempDirectory)
+	s.Config.Logger.Debug("Moving to: %s", targetDirectory)
 
 	err = os.Rename(tempDirectory, targetDirectory)
 	if err != nil {
@@ -187,7 +187,7 @@ func (s *Service) List() error {
 
 		semver, err := semver.Parse(entry.Name())
 		if err != nil {
-			s.Config.Logger.Trace("Failed to recognize version: %s", err)
+			s.Config.Logger.Warning("Failed to recognize version: %s", err)
 			continue
 		}
 

--- a/internal/services/godot/godot.go
+++ b/internal/services/godot/godot.go
@@ -25,7 +25,7 @@ type Service struct {
 }
 
 func (s *Service) Download(semver semver.Semver) error {
-	s.Config.Logger.Trace("Attempting to download '%s' godot...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to download '%s' godot...", semver.GodotString())
 
 	asset, err := s.Environment.FetchGodotAsset(semver)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -48,8 +48,8 @@ func (s *Service) Download(semver semver.Semver) error {
 		return nil
 	}
 
-	s.Config.Logger.Trace("Downloading from: %s", asset.DownloadURL)
-	s.Config.Logger.Trace("Downloading to: %s", archivePath)
+	s.Config.Logger.Debug("Downloading from: %s", asset.DownloadURL)
+	s.Config.Logger.Debug("Downloading to: %s", archivePath)
 
 	err = downloading.Download(s.Config.Logger, asset.DownloadURL, archivePath, s.Config.Silent)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -65,7 +65,7 @@ func (s *Service) Download(semver semver.Semver) error {
 }
 
 func (s *Service) Uninstall(semver semver.Semver, logMissing bool) error {
-	s.Config.Logger.Trace("Attempting to uninstall '%s' godot...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to uninstall '%s' godot...", semver.GodotString())
 
 	targetDirectory := s.targetDirectory(semver)
 
@@ -82,7 +82,7 @@ func (s *Service) Uninstall(semver semver.Semver, logMissing bool) error {
 		return nil
 	}
 
-	s.Config.Logger.Trace("Removing directory: %s", targetDirectory)
+	s.Config.Logger.Debug("Removing directory: %s", targetDirectory)
 
 	err = os.RemoveAll(targetDirectory)
 	if err != nil {
@@ -94,7 +94,7 @@ func (s *Service) Uninstall(semver semver.Semver, logMissing bool) error {
 }
 
 func (s *Service) Install(semver semver.Semver) error {
-	s.Config.Logger.Trace("Attempting to install '%s' godot...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to install '%s' godot...", semver.GodotString())
 
 	asset, err := s.Environment.FetchGodotAsset(semver)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -128,8 +128,8 @@ func (s *Service) Install(semver semver.Semver) error {
 		return fmt.Errorf("cannot remove target directory: %w", err)
 	}
 
-	s.Config.Logger.Trace("Downloading from: %s", asset.DownloadURL)
-	s.Config.Logger.Trace("Downloading to: %s", archivePath)
+	s.Config.Logger.Debug("Downloading from: %s", asset.DownloadURL)
+	s.Config.Logger.Debug("Downloading to: %s", archivePath)
 
 	err = downloading.Download(s.Config.Logger, asset.DownloadURL, archivePath, s.Config.Silent)
 	if errors.Is(err, downloading.ErrNotFound) {
@@ -140,8 +140,8 @@ func (s *Service) Install(semver semver.Semver) error {
 		return fmt.Errorf("download failed: %w", err)
 	}
 
-	s.Config.Logger.Trace("Unzipping from: %s", archivePath)
-	s.Config.Logger.Trace("Unzipping to: %s", targetDirectory)
+	s.Config.Logger.Debug("Unzipping from: %s", archivePath)
+	s.Config.Logger.Debug("Unzipping to: %s", targetDirectory)
 
 	err = archiving.Unzip(s.Config.Logger, archivePath, targetDirectory)
 	if err != nil {
@@ -153,7 +153,7 @@ func (s *Service) Install(semver semver.Semver) error {
 }
 
 func (s *Service) Use(semver semver.Semver) error {
-	s.Config.Logger.Trace("Attempting to use '%s' godot...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to use '%s' godot...", semver.GodotString())
 
 	targetPath, err := s.Locator.TargetPath(semver)
 	if errors.Is(err, os.ErrNotExist) {
@@ -166,7 +166,7 @@ func (s *Service) Use(semver semver.Semver) error {
 
 	linkPath := s.Locator.LinkPath(semver)
 
-	s.Config.Logger.Trace("Creating godot symlink: %s => %s", linkPath, targetPath)
+	s.Config.Logger.Debug("Creating godot symlink: %s => %s", linkPath, targetPath)
 
 	err = os.MkdirAll(s.Config.BinDirectory, utils.OS_DIRECTORY)
 	if err != nil {
@@ -222,7 +222,7 @@ func (s *Service) List() error {
 
 		semver, err := semver.Parse(entry.Name())
 		if err != nil {
-			s.Config.Logger.Trace("Failed to recognize version: %s", err)
+			s.Config.Logger.Warning("Failed to recognize version: %s", err)
 			continue
 		}
 

--- a/internal/services/settings/settings.go
+++ b/internal/services/settings/settings.go
@@ -17,6 +17,8 @@ type Service struct {
 }
 
 func (s *Service) Reset() error {
+	s.Config.Logger.Debug("Attempting to reset settings...")
+
 	err := s.Config.Reset()
 	if err != nil {
 		return fmt.Errorf("cannot reset config: %w", err)

--- a/internal/services/shortcuts/application/application.go
+++ b/internal/services/shortcuts/application/application.go
@@ -18,11 +18,11 @@ type Service struct {
 }
 
 func (s *Service) Remove(semver semver.Semver, logMissing bool) error {
-	s.Config.Logger.Trace("Attempting to remove '%s' application shortcut...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to remove '%s' application shortcut...", semver.GodotString())
 
 	shortcutPath := s.Locator.ApplicationShortcutPath(semver)
 
-	s.Config.Logger.Trace("Removing application shortcut: %s", shortcutPath)
+	s.Config.Logger.Debug("Removing application shortcut: %s", shortcutPath)
 
 	exists, err := utils.DoesExist(shortcutPath)
 	if err != nil {
@@ -47,7 +47,7 @@ func (s *Service) Remove(semver semver.Semver, logMissing bool) error {
 }
 
 func (s *Service) Add(semver semver.Semver) error {
-	s.Config.Logger.Trace("Attempting to add '%s' application shortcut...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to add '%s' application shortcut...", semver.GodotString())
 
 	targetPath, err := s.Locator.TargetPath(semver)
 	if errors.Is(err, os.ErrNotExist) {
@@ -61,7 +61,7 @@ func (s *Service) Add(semver semver.Semver) error {
 	shortcutPath := s.Locator.ApplicationShortcutPath(semver)
 	shortcutName := s.Locator.ShortcutName(semver)
 
-	s.Config.Logger.Trace("Adding '%s' application shortcut: %s => %s", shortcutName, shortcutPath, targetPath)
+	s.Config.Logger.Debug("Adding '%s' application shortcut: %s => %s", shortcutName, shortcutPath, targetPath)
 
 	exists, err := utils.DoesExist(shortcutPath)
 	if err != nil {

--- a/internal/services/shortcuts/desktop/desktop.go
+++ b/internal/services/shortcuts/desktop/desktop.go
@@ -18,11 +18,11 @@ type Service struct {
 }
 
 func (s *Service) Remove(semver semver.Semver, logMissing bool) error {
-	s.Config.Logger.Trace("Attempting to remove '%s' desktop shortcut...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to remove '%s' desktop shortcut...", semver.GodotString())
 
 	shortcutPath := s.Locator.DesktopShortcutPath(semver)
 
-	s.Config.Logger.Trace("Removing desktop shortcut: %s", shortcutPath)
+	s.Config.Logger.Debug("Removing desktop shortcut: %s", shortcutPath)
 
 	exists, err := utils.DoesExist(shortcutPath)
 	if err != nil {
@@ -47,7 +47,7 @@ func (s *Service) Remove(semver semver.Semver, logMissing bool) error {
 }
 
 func (s *Service) Add(semver semver.Semver) error {
-	s.Config.Logger.Trace("Attempting to add '%s' desktop shortcut...", semver.GodotString())
+	s.Config.Logger.Debug("Attempting to add '%s' desktop shortcut...", semver.GodotString())
 
 	targetPath, err := s.Locator.TargetPath(semver)
 	if errors.Is(err, os.ErrNotExist) {
@@ -61,7 +61,7 @@ func (s *Service) Add(semver semver.Semver) error {
 	shortcutPath := s.Locator.DesktopShortcutPath(semver)
 	shortcutName := s.Locator.ShortcutName(semver)
 
-	s.Config.Logger.Trace("Adding '%s' desktop shortcut: %s => %s", shortcutName, shortcutPath, targetPath)
+	s.Config.Logger.Debug("Adding '%s' desktop shortcut: %s => %s", shortcutName, shortcutPath, targetPath)
 
 	exists, err := utils.DoesExist(shortcutPath)
 	if err != nil {


### PR DESCRIPTION
When fetching downloads from github it was possible that some assets might get overridden or not be mapped at all.
- Log warning when multiple assets found for the same platform (had to also create overrides to allow for osx universal builds to splat over 64/32 builds)
- Log warning when an asset is not mapped to any platform

Also made some small optimisations in this area by only doing the regex for the asset a single time per asset data.

Adjusted the log levels to better suit everyday use.